### PR TITLE
Update compile-lmdb-macos.sh

### DIFF
--- a/lmdb/Brewfile
+++ b/lmdb/Brewfile
@@ -1,4 +1,8 @@
 # Using mingw to compile Windows native libs for x86 and x64
 brew "mingw-w64"
+
+# Using llvm-mingw for Windows ARM64 cross-compilation
+brew "llvm-mingw/mingw/llvm-mingw"
+
 brew "emscripten"
 cask "android-ndk"

--- a/lmdb/compile-lmdb-macos.sh
+++ b/lmdb/compile-lmdb-macos.sh
@@ -19,6 +19,7 @@ declare -A supported_targets=(
   [linux-x64/native/liblmdb.so]="docker run --mount type=bind,source=$(pwd),target=/lmdb --rm --platform=linux/amd64 -w /lmdb gcc:latest make LDFLAGS='-s' XCFLAGS='-DNDEBUG'"
   [win-x64/native/lmdb.dll]="make CC='x86_64-w64-mingw32-gcc' AR='x86_64-w64-mingw32-gcc-ar' LDFLAGS='-s' XCFLAGS='-DNDEBUG'"
   [win-x86/native/lmdb.dll]="make CC='i686-w64-mingw32-gcc' AR='i686-w64-mingw32-gcc-ar' LDFLAGS='-s' XCFLAGS='-DNDEBUG'"
+  [win-arm64/native/lmdb.dll]="make CC='aarch64-w64-mingw32-gcc' AR='aarch64-w64-mingw32-gcc-ar' LDFLAGS='-s' XCFLAGS='-DNDEBUG'"
   [android-arm64/native/liblmdb.so]="make CC=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang AR=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar LDFLAGS='-s' XCFLAGS='-UMDB_USE_ROBUST -DMDB_USE_POSIX_MUTEX -DANDROID -DNDEBUG'"
   [android-arm/native/liblmdb.so]="make CC=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi21-clang AR=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar LDFLAGS='-s' XCFLAGS='-UMDB_USE_ROBUST -DMDB_USE_POSIX_MUTEX -DANDROID -DNDEBUG'"
   [android-x86/native/liblmdb.so]="make CC=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android21-clang AR=$NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar LDFLAGS='-s' XCFLAGS='-UMDB_USE_ROBUST -DMDB_USE_POSIX_MUTEX -DANDROID -DNDEBUG'"


### PR DESCRIPTION
Add Windows ARM64 entry

If your system has mingw-w64 with ARM64 target installed, the compiler/archiver names are:

aarch64-w64-mingw32-gcc

aarch64-w64-mingw32-gcc-ar